### PR TITLE
Test ecdsa-sha2 key format in sflogs

### DIFF
--- a/zuul.d/_secret_sflogs.yaml
+++ b/zuul.d/_secret_sflogs.yaml
@@ -3,7 +3,7 @@
     data:
       fqdn: ansible-test.softwarefactory-project.io
       path: /var/www/logs
-      ssh_known_hosts: ansible-test.softwarefactory-project.io ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwBUZ2QKF+Z6HILq+jmQ8wWe4fN9/7VW+Jhg/mrzKbL6NAR11mPVC6JUeMB0CeYkXGMuac2SZYPknrVScjHp5HlFToQOAvSiJTSkuQeexTHOEcVHVjhTAmfGw4MoLm6whRecX+58aMkXdf9AFvPPJm9Nh3/yvWhJy8QdxpuuK4NuPkck1adsRlIc3fb8gMkGdgRX550TKPCY/sT2eQyKtwWKtkL7yYIJn4CKmcpGczNjDlSeVKyjAnBgcmVGY002j8cQFDq5D4KCaERRLWzlDA+Ur+ZoyA3smNcMIGohDlvhNRZSxQ3GtgH7diHiL0PD8NkiMTj8mde+o5vuYo2tdL
+      ssh_known_hosts: ansible-test.softwarefactory-project.io ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMjio5M3O5l0nzEnhcRGLcRb/D/mBoT1q8A/2Xn2wAMWNDFQ0zxcH3lSJQkZMG2Uee6p48o9epXNze0WzwuCeEo=
       ssh_username: loguser
       ssh_private_key: !encrypted/pkcs1-oaep
         - jTmgJyrtmgMAboYxlRQcRazK9PBl+jLd/7y+5wu90VJ9pfee8467f5kKMduFE5cQroQwv


### PR DESCRIPTION
This is an attempt at reproducing a weird post_failure in tenant config-update